### PR TITLE
Potential fix for code scanning alert no. 12: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build-base.yaml
+++ b/.github/workflows/build-base.yaml
@@ -7,6 +7,8 @@ on:
         type: string
         required: true
 
+permissions:
+  contents: read
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/mc-cloud-town/Carpet-Vastech-Addition/security/code-scanning/12](https://github.com/mc-cloud-town/Carpet-Vastech-Addition/security/code-scanning/12)

To fix the problem, add a `permissions` block to the workflow to restrict the GITHUB_TOKEN permissions to the minimum required. Since the workflow only checks out code, builds, caches dependencies, and uploads artifacts, it does not need write access to repository contents. The best fix is to add `permissions: contents: read` at the top level of the workflow (before `jobs:`), which will apply to all jobs unless overridden. This change should be made at the root of `.github/workflows/build-base.yaml`, above the `jobs:` key.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
