### PR TITLE
Potential fix for code scanning alert no. 10: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,5 +1,8 @@
 name: Release
 
+permissions:
+  contents: write
+
 on:
   push:
     tags:


### PR DESCRIPTION
Potential fix for [https://github.com/mc-cloud-town/Carpet-Vastech-Addition/security/code-scanning/10](https://github.com/mc-cloud-town/Carpet-Vastech-Addition/security/code-scanning/10)

To fix the problem, add a `permissions` block to the workflow file to explicitly specify the minimum required permissions for the jobs. Since the workflow uses `softprops/action-gh-release@v2` to upload release assets, it requires `contents: write`. Other steps (such as `actions/checkout` and `actions/download-artifact`) do not require additional permissions. The best way to fix this is to add a `permissions` block at the workflow root (applies to all jobs), or at the `release` job level if only that job needs elevated permissions. For clarity and least privilege, set `permissions: contents: write` at the workflow root, unless you know the `build` job does not need it, in which case you can set `permissions: contents: write` only for the `release` job.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
