### PR TITLE
Potential fix for code scanning alert no. 8: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/mc-cloud-town/Carpet-Vastech-Addition/security/code-scanning/8](https://github.com/mc-cloud-town/Carpet-Vastech-Addition/security/code-scanning/8)

To fix the problem, you should add a `permissions` block to the workflow file `.github/workflows/CI.yaml`. This block can be added at the root level (recommended for workflows that do not require any write access) or at the job level if different jobs require different permissions. Since the provided workflow only delegates to another workflow via `uses: ./.github/workflows/build-base.yaml`, and unless you know that write access is required, the minimal safe default is to set `contents: read`. This change should be made near the top of the file, after the `name` and before the `on` block, or at the job level if more granularity is needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
