### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,4 +1,7 @@
 name: Release
+permissions:
+  contents: write
+  actions: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/mc-cloud-town/Carpet-Vastech-Addition/security/code-scanning/6](https://github.com/mc-cloud-town/Carpet-Vastech-Addition/security/code-scanning/6)

To fix the problem, you should add a `permissions` block to the workflow file `.github/workflows/release.yaml`. The block should be placed at the top level (just after the `name:` and before `jobs:`) to apply to all jobs in the workflow, unless a job needs more specific permissions. For this workflow, the minimal required permissions are likely `contents: write` (for uploading release assets and creating releases) and possibly `actions: read` (for downloading artifacts). You should not grant broader permissions than necessary. The change involves inserting the following block:

```yaml
permissions:
  contents: write
  actions: read
```

immediately after the `name: Release` line and before the `on:` block.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
